### PR TITLE
Feature/thread safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,15 @@ will deliver the messages in batches no larger than 4 Mb anyway.
 Asynchronous Usage
 ------------------
 
-StitchClient is *not* thread-safe. Calling any of methods concurrently
-can result in lost or corrupt data. If your application has multiple
-threads producing data, we recommend using a separate client for each
-thread.
+It is safe for multiple threads to call `push` on a single instance of
+`StitchClient`. If buffering is enabled (which it is by default), then
+multiple threads will accumulate records into the same batch. When one
+of those threads makes a call to `push` that causes the buffer to fill
+up, that thread will deliver the entire batch to Stitch. This behavior
+should be suitable for many applications. However, if you do not want
+records from multiple threads to be sent on the same batch, or if you
+want to ensure that a record is only delivered by the thread that
+produced it, then you can create a separate StitchClient for each thread.
 
 License
 -------

--- a/pom.xml
+++ b/pom.xml
@@ -29,17 +29,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.2.1</version>

--- a/src/main/java/com/stitchdata/client/Buffer.java
+++ b/src/main/java/com/stitchdata/client/Buffer.java
@@ -41,10 +41,13 @@ public class Buffer {
         }
     }
 
-    public void putMessage(Map map) {
-        Entry entry = new Entry(map);
+    private synchronized void putEntry(Entry entry) {
         queue.add(entry);
         availableBytes += entry.bytes.length;
+    }
+
+    public void putMessage(Map map) {
+        putEntry(new Entry(map));
     }
 
     public String takeBatch(int batchSizeBytes, int batchDelayMillis) throws IOException {

--- a/src/main/java/com/stitchdata/client/Buffer.java
+++ b/src/main/java/com/stitchdata/client/Buffer.java
@@ -3,12 +3,11 @@ package com.stitchdata.client;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.Queue;
 import java.util.LinkedList;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import com.cognitect.transit.Writer;
 import com.cognitect.transit.TransitFactory;
 import com.cognitect.transit.Reader;
@@ -20,6 +19,48 @@ public class Buffer {
 
     private final Queue<Entry> queue = new LinkedList<Entry>();
     private int availableBytes = 0;
+
+    // Synchronized methods for accessing the properties (queue and
+    // availableBytes)
+
+    private synchronized void putEntry(Entry entry) {
+        queue.add(entry);
+        availableBytes += entry.bytes.length;
+    }
+
+    private synchronized List<Entry> takeEntries(int batchSizeBytes, int batchDelayMillis) {
+        if (queue.isEmpty()) {
+            return null;
+        }
+
+        boolean ready =
+            availableBytes >= batchSizeBytes ||
+            queue.size() >= MAX_MESSAGES_PER_BATCH ||
+            System.currentTimeMillis() - queue.peek().entryTime >= batchDelayMillis;
+
+        if (!ready) {
+            return null;
+        }
+
+        ArrayList<Entry> entries = new ArrayList<Entry>();
+
+        // Start size at 2 to allow for opening and closing brackets
+        int size = 2;
+        while (!queue.isEmpty() &&
+               size + queue.peek().bytes.length < MAX_BATCH_SIZE_BYTES) {
+            Entry entry = queue.remove();
+            // Add size of record plus the comma delimiter
+            size += entry.bytes.length + 1;
+            availableBytes -= entry.bytes.length;
+            entries.add(entry);
+        }
+
+        return entries;
+    }
+
+    // Static stuff. Class for wrapping a Map in an Entry, and method
+    // for serializing a list of entries. Since these don't access
+    // queue or availableBytes, they don't need to be synchronized.
 
     private static class Entry {
         byte[] bytes;
@@ -41,41 +82,14 @@ public class Buffer {
         }
     }
 
-    private synchronized void putEntry(Entry entry) {
-        queue.add(entry);
-        availableBytes += entry.bytes.length;
-    }
-
-    public void putMessage(Map map) {
-        putEntry(new Entry(map));
-    }
-
-    public String takeBatch(int batchSizeBytes, int batchDelayMillis) throws IOException {
-
-        if (queue.isEmpty()) {
-            return null;
-        }
-
-        boolean ready =
-            availableBytes >= batchSizeBytes ||
-            queue.size() >= MAX_MESSAGES_PER_BATCH ||
-            System.currentTimeMillis() - queue.peek().entryTime >= batchDelayMillis;
-
-        if (!ready) {
+    private static String serializeEntries(List<Entry> entries) throws UnsupportedEncodingException {
+        if (entries == null) {
             return null;
         }
 
         ArrayList<Map> messages = new ArrayList<Map>();
 
-        // Start size at 2 to allow for opening and closing brackets
-        int size = 2;
-        while (!queue.isEmpty() &&
-               size + queue.peek().bytes.length < MAX_BATCH_SIZE_BYTES) {
-            Entry entry = queue.remove();
-            // Add size of record plus the comma delimiter
-            size += entry.bytes.length + 1;
-            availableBytes -= entry.bytes.length;
-            Map map;
+        for (Entry entry : entries) {
             ByteArrayInputStream bais = new ByteArrayInputStream(entry.bytes);
             Reader reader = TransitFactory.reader(TransitFactory.Format.JSON, bais);
             messages.add((Map)reader.read());
@@ -85,6 +99,14 @@ public class Buffer {
         Writer writer = TransitFactory.writer(TransitFactory.Format.JSON, baos);
         writer.write(messages);
         return baos.toString("UTF-8");
+    }
+
+    public void putMessage(Map map) {
+        putEntry(new Entry(map));
+    }
+
+    public String takeBatch(int batchSizeBytes, int batchDelayMillis) throws IOException {
+        return serializeEntries(takeEntries(batchSizeBytes, batchDelayMillis));
     }
 
 }

--- a/src/main/java/com/stitchdata/client/Buffer.java
+++ b/src/main/java/com/stitchdata/client/Buffer.java
@@ -25,7 +25,7 @@ public class Buffer {
         byte[] bytes;
         private long entryTime;
 
-        private Entry(Map map) throws IOException {
+        private Entry(Map map) {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             Writer writer = TransitFactory.writer(TransitFactory.Format.JSON, baos);
             writer.write(map);

--- a/src/main/java/com/stitchdata/client/Buffer.java
+++ b/src/main/java/com/stitchdata/client/Buffer.java
@@ -8,6 +8,7 @@ import java.util.LinkedList;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
+import java.io.IOException;
 import com.cognitect.transit.Writer;
 import com.cognitect.transit.TransitFactory;
 import com.cognitect.transit.Reader;

--- a/src/main/java/com/stitchdata/client/StitchClient.java
+++ b/src/main/java/com/stitchdata/client/StitchClient.java
@@ -63,9 +63,16 @@ import javax.json.JsonReader;
  * }
  * </pre>
  *
- * Note that instanes of StitchClient are not thread-safe. Concurrent
- * calls to {@link #push(StitchMessage)} can result in lost or corrupt
- * data.
+ * Instances of StitchClient are thread-safe. If buffering is enabled
+ * (which it is by default), then multiple threads will accumulate
+ * records into the same batch. When one of those threads makes a call
+ * to {@link #push(StitchMessage)} that causes the buffer to fill up,
+ * that thread will deliver the entire batch to Stitch. This behavior
+ * should be suitable for many applications. However, if you do not
+ * want records from multiple threads to be sent on the same batch, or
+ * if you want to ensure that a record is only delivered by the thread
+ * that produced it, then you can create a separate StitchClient for
+ * each thread.
  */
 public class StitchClient implements Flushable, Closeable {
 

--- a/src/main/java/com/stitchdata/client/StitchClient.java
+++ b/src/main/java/com/stitchdata/client/StitchClient.java
@@ -179,7 +179,7 @@ public class StitchClient implements Flushable, Closeable {
         }
     }
 
-    private void sendBatch(String batch) throws IOException {
+    void sendBatch(String batch) throws IOException {
         Request request = Request.Post(stitchUrl)
             .connectTimeout(connectTimeout)
             .addHeader("Authorization", "Bearer " + token)

--- a/src/test/java/com/stitchdata/client/StitchClientTest.java
+++ b/src/test/java/com/stitchdata/client/StitchClientTest.java
@@ -1,0 +1,120 @@
+package com.stitchdata.client;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import com.cognitect.transit.TransitFactory;
+import com.cognitect.transit.Reader;
+import org.junit.*;
+import static org.junit.Assert.*;
+
+public class StitchClientTest  {
+
+    private static final int NUM_THREADS = 4;
+    private static final int NUM_RECORDS_PER_THREAD = 10000;
+
+    List<AtomicInteger> numRecordsByThreadId = new ArrayList<AtomicInteger>();
+
+    private class DummyStitchClient extends StitchClient {
+
+        DummyStitchClient() {
+            super(PUSH_URL, 0, null, null, null, Arrays.asList(new String[] { "id" }), StitchClientBuilder.DEFAULT_BATCH_SIZE_BYTES, 60000000);
+        }
+
+        @Override
+        void sendBatch(String batch) throws IOException {
+
+            ByteArrayInputStream bais = new ByteArrayInputStream(batch.getBytes());
+            Reader reader = TransitFactory.reader(TransitFactory.Format.JSON, bais);
+            List records = reader.read();
+            int counts[] = new int[NUM_THREADS];
+            for (int i = 0; i < NUM_THREADS; i++) {
+                counts[i] = 0;
+            }
+            for (Object record : records) {
+                Map data = (Map) ((Map)record).get("data");
+                int threadId = ((Long) ((Map)data).get("threadId")).intValue();
+                counts[threadId]++;
+                numRecordsByThreadId.get(threadId).incrementAndGet();
+            }
+
+            // For debugging
+            // System.err.print("Sent a batch of size " + batch.length() + "; counts are");
+            // for (int i = 0; i < NUM_THREADS; i++) {
+            //     System.err.print(" " + counts[i]);
+            // }
+            // System.err.println("");
+        }
+    }
+
+    @Before
+    public void clearNumRecordsByThreadId() {
+        for (int i = 0; i < NUM_THREADS; i++) {
+            numRecordsByThreadId.add(new AtomicInteger(0));
+        }
+    }
+
+    public static class Sender implements Runnable {
+        private Map record = new HashMap();
+        private final int threadId;
+        private final StitchClient stitch;
+
+        public Sender(StitchClient stitch, int threadId) {
+            this.threadId = threadId;
+            this.stitch = stitch;
+
+            char chars[] = new char[100];
+            Arrays.fill(chars, 'b');
+            record.put("threadId", threadId);
+            record.put("a", new String(chars));
+        }
+
+        public void run() {
+            for (int recordId = 0; recordId < NUM_RECORDS_PER_THREAD; recordId++) {
+                record.put("recordId", recordId);
+                try {
+                    stitch.push(StitchMessage.newUpsert()
+                                .withSequence(0)
+                                .withData(record));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testConcurrentPushes() throws IOException {
+
+        List<Thread> threads = new ArrayList<Thread>();
+        final ArrayList<Map> records = new ArrayList<Map>();
+
+        try (StitchClient stitch = new DummyStitchClient()) {
+            for (int i = 0; i < NUM_THREADS; i++) {
+                threads.add(new Thread(new Sender(stitch, i)));
+            }
+
+            for (Thread thread : threads) {
+                thread.start();
+            }
+
+            for (Thread thread : threads) {
+                try {
+                    thread.join();
+                } catch (InterruptedException e) {
+                    // Do nothing
+                }
+            }
+
+            for (int i = 0; i < NUM_THREADS; i++) {
+                assertEquals(NUM_RECORDS_PER_THREAD, numRecordsByThreadId.get(i).get());
+            }
+        }
+    }
+}


### PR DESCRIPTION
StitchClient was not thread safe. It was pretty easy to make it thread safe, by synchronizing access to the properties of the Buffer object. I refactored the Buffer object to reduce the scope where the private properties (queue and availableBytes) are accessed, and then made those methods synchronized.

## Testing

It's not an exhaustive test, but I added a test that at least attempts to exercise concurrent calls to push(). Please see docs in the test class for details.