### PR TITLE
Avoid JSON parsing errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
   <groupId>com.stitchdata</groupId>
   <artifactId>java-stitch-client</artifactId>
   <description>Java Stitch Client</description>
-  <version>0.5.4</version>
+  <version>0.5.5-SNAPSHOT</version>
   <url>https://github.com/stitchdata/java-stitch-client</url>
   <scm>
     <url>https://github.com/stitchdata/java-stitch-client</url>
     <connection>scm:git:git@github.com:stitchdata/java-stitch-client.git</connection>
-    <tag>java-stitch-client-0.5.4</tag>
+    <tag>\</tag>
   </scm>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
   <groupId>com.stitchdata</groupId>
   <artifactId>java-stitch-client</artifactId>
   <description>Java Stitch Client</description>
-  <version>0.5.4-SNAPSHOT</version>
+  <version>0.5.4</version>
   <url>https://github.com/stitchdata/java-stitch-client</url>
   <scm>
     <url>https://github.com/stitchdata/java-stitch-client</url>
     <connection>scm:git:git@github.com:stitchdata/java-stitch-client.git</connection>
-    <tag>\</tag>
+    <tag>java-stitch-client-0.5.4</tag>
   </scm>
   <developers>
     <developer>

--- a/src/main/java/com/stitchdata/client/FlushHandler.java
+++ b/src/main/java/com/stitchdata/client/FlushHandler.java
@@ -11,6 +11,9 @@ public interface FlushHandler {
     /**
      * Called after a successful flush, with the list of callbackArgs
      * corresponding to the records that were flushed.
+     *
+     * @param callbackArgs the callbackArgs associated with the records
+     *                     that were flushed.
      */
     public void onFlush(List callbackArgs);
 }

--- a/src/main/java/com/stitchdata/client/StitchClient.java
+++ b/src/main/java/com/stitchdata/client/StitchClient.java
@@ -189,6 +189,7 @@ public class StitchClient implements Flushable, Closeable {
      * sent immediately and this function will block until it is
      * delivered.</p>
      *
+     * @param message the message
      * @throws StitchException if Stitch rejected or was unable to
      *                         process the message
      * @throws IOException if there was an error communicating with
@@ -216,6 +217,9 @@ public class StitchClient implements Flushable, Closeable {
      * sent immediately and this function will block until it is
      * delivered.</p>
      *
+     * @param message the message
+     * @param callbackArg flush handler will be invoked with this as 
+     *                    one of the callbackArgs.
      * @throws StitchException if Stitch rejected or was unable to
      *                         process the message
      * @throws IOException if there was an error communicating with

--- a/src/main/java/com/stitchdata/client/StitchClient.java
+++ b/src/main/java/com/stitchdata/client/StitchClient.java
@@ -253,7 +253,6 @@ public class StitchClient implements Flushable, Closeable {
             JsonReader rdr = Json.createReader(response.getEntity().getContent());
             content = rdr.readObject();
         }
-
         return new StitchResponse(statusCode, reasonPhrase, content);
     }
 

--- a/src/main/java/com/stitchdata/client/StitchClientBuilder.java
+++ b/src/main/java/com/stitchdata/client/StitchClientBuilder.java
@@ -87,7 +87,7 @@ import javax.json.JsonReader;
  * StitchClientBuilder#withBatchSizeBytes(int)} and {@link
  * StitchClientBuilder#withBatchDelayMillis(int)}. Setting
  * batchSizeBytes to 0 will effectively disable batching and cause
- * each call to {@link StitchClient.#push(StitchMessage)} to send the
+ * each call to {@link StitchClient#push(StitchMessage)} to send the
  * record immediatley.
  *
  * <pre>
@@ -262,6 +262,9 @@ public class StitchClientBuilder {
      * Set the URL to use when submitting records, to override the
      * default Stitch URL. Note that this only makes sense for testing
      * purposes.
+     *
+     * @param the url to use
+     * @return this object
      */
     public StitchClientBuilder withPushUrl(String pushUrl) {
         this.pushUrl = pushUrl;
@@ -269,7 +272,10 @@ public class StitchClientBuilder {
     }
 
     /**
-     * Set an custom write handlers to be used during the transit encoding.
+     * Set custom write handlers to be used during the transit encoding.
+     *
+     * @param writeHandlers the write handlers
+     * @return this object
      */
     public StitchClientBuilder withWriteHandlers(Map<Class,WriteHandler<?,?>> writeHandlers) {
         this.writeHandlers = writeHandlers;

--- a/src/main/java/com/stitchdata/client/StitchClientBuilder.java
+++ b/src/main/java/com/stitchdata/client/StitchClientBuilder.java
@@ -263,7 +263,7 @@ public class StitchClientBuilder {
      * default Stitch URL. Note that this only makes sense for testing
      * purposes.
      *
-     * @param the url to use
+     * @param pushUrl the url to use
      * @return this object
      */
     public StitchClientBuilder withPushUrl(String pushUrl) {

--- a/src/main/java/com/stitchdata/client/StitchMessage.java
+++ b/src/main/java/com/stitchdata/client/StitchMessage.java
@@ -44,6 +44,9 @@ public class StitchMessage {
 
     /**
      * Set the action and return this message.
+     *
+     * @param action the action
+     * @return this object
      */
     public StitchMessage withAction(Action action) {
         this.action = action;
@@ -154,6 +157,9 @@ public class StitchMessage {
      * Regardless of the order in which the records are processed by
      * the loader, the end result will be that "status" for order
      * number 123 will be "completed".
+     *
+     * @param sequence sequence number
+     * @return this object
      */
     public StitchMessage withSequence(long sequence) {
         this.sequence = sequence;
@@ -166,6 +172,9 @@ public class StitchMessage {
      * modify the map until after the message is pushed via {@link
      * StitchClient#push(StitchMessage)}. After that point, it is safe to
      * modify and reuse the map.
+     *
+     * @param data body of the message
+     * @return this object
      */
     public StitchMessage withData(Map data) {
         this.data = data;

--- a/src/main/java/com/stitchdata/client/StitchResponse.java
+++ b/src/main/java/com/stitchdata/client/StitchResponse.java
@@ -42,8 +42,11 @@ public class StitchResponse {
     }
 
     public String toString() {
-        String details = content.toString();
-        return "HTTP Status Code " + httpStatusCode +
-            " (" + httpReasonPhrase + "): " + details;
+        String result = "HTTP Status Code " + httpStatusCode +
+            " (" + httpReasonPhrase + ")";
+        if (content != null) {
+            result += ": " + content.toString();
+        }
+        return result;
     }
 }


### PR DESCRIPTION
We were not checking status code or content type before trying to parse the content of the response. This changes it so we only attempt to parse the response as JSON if the status code is < 500 and the content type is application/json.