### PR TITLE
Include more info in exception

### DIFF
--- a/src/main/java/com/stitchdata/client/Buffer.java
+++ b/src/main/java/com/stitchdata/client/Buffer.java
@@ -70,7 +70,7 @@ public class Buffer {
             if (bytes.length > MAX_BATCH_SIZE_BYTES - 2) {
                 throw new IllegalArgumentException(
                     "Can't accept a record larger than " + (MAX_BATCH_SIZE_BYTES - 2)
-                    + " bytes");
+                    + " bytes (is " + bytes.length + "bytes)");
             }
         }
     }


### PR DESCRIPTION
Just got a strike team ticket where this error was triggered but had no other context. Would like to know how large the rejected data is.